### PR TITLE
Fix: (Button, Encoder, Switch) Initialize pins only of not on multiplexers

### DIFF
--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -14,7 +14,9 @@ Button::Button(uint8_t mux, uint8_t pin)
   _state = 0;
   _transition = 0;
   _cmdPush = -1;
-  pinMode(_pin, INPUT_PULLUP);
+  if(mux == NOT_USED) {
+    pinMode(_pin, INPUT_PULLUP);
+  }
 }
 
 // use additional bit for input masking

--- a/src/Encoder.cpp
+++ b/src/Encoder.cpp
@@ -20,11 +20,13 @@ Encoder::Encoder(uint8_t mux, uint8_t pin1, uint8_t pin2, uint8_t pin3, EncPulse
   _cmdUp = -1;
   _cmdDown = -1;
   _cmdPush = -1;
-  pinMode(_pin1, INPUT_PULLUP);
-  pinMode(_pin2, INPUT_PULLUP);
-  if (_pin3 != NOT_USED)
-  {
-    pinMode(_pin3, INPUT_PULLUP);
+  if(mux == NOT_USED) {
+    pinMode(_pin1, INPUT_PULLUP);
+    pinMode(_pin2, INPUT_PULLUP);
+    if (_pin3 != NOT_USED)
+    {
+        pinMode(_pin3, INPUT_PULLUP);
+    }
   }
 }
 

--- a/src/Switch.cpp
+++ b/src/Switch.cpp
@@ -13,7 +13,9 @@ Switch::Switch(uint8_t mux, uint8_t pin)
   _state = switchOff;
   _cmdOn = -1;
   _cmdOff = -1;
-  pinMode(_pin, INPUT_PULLUP);
+  if(mux == NOT_USED) {
+    pinMode(_pin, INPUT_PULLUP);
+  }
 }
 
 void Switch::handle()


### PR DESCRIPTION
Modified class constructors; class Switch2 was already correct.